### PR TITLE
Preventing setting test script to "xo && xo"

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (opts, cb) {
 
 	if (s.test && s.test !== DEFAULT_TEST_SCRIPT) {
 		// don't add if it's already there
-		if (!/^xo /.test(s.test)) {
+		if (!/^xo( |$)/.test(s.test)) {
 			s.test = 'xo && ' + s.test;
 		}
 	} else {

--- a/test.js
+++ b/test.js
@@ -51,6 +51,18 @@ test('has default test', function (t) {
 	});
 });
 
+test('has only xo', function (t) {
+	t.plan(3);
+
+	run(t, {
+		scripts: {
+			test: 'xo'
+		}
+	}, function (pkg) {
+		t.assert(dotProp.get(pkg, 'scripts.test') === 'xo');
+	});
+});
+
 test('has test', function (t) {
 	t.plan(3);
 


### PR DESCRIPTION
Creating a new node package using `npm init -y` and then running `xo --init` will correctly set `scripts.test` to `"xo"`.

If running `xo` a second time on such package will result in `scripts.test` being set to `"xo && xo"`. This PR fixes that.
