### PR TITLE
Making it possible to use extra args on init

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@ var fs = require('fs');
 var path = require('path');
 var childProcess = require('child_process');
 var lookUp = require('look-up');
-var hasFlag = require('has-flag');
+var minimist = require('minimist');
+var arrify = require('arrify');
+var argv = require('the-argv');
 var DEFAULT_TEST_SCRIPT = 'echo "Error: no test specified" && exit 1';
 
 module.exports = function (opts, cb) {
@@ -15,6 +17,7 @@ module.exports = function (opts, cb) {
 	cb = cb || function () {};
 
 	var cwd = opts.cwd || process.cwd();
+	var args = opts.args || argv();
 
 	var pkg;
 	var pkgPath = lookUp('package.json', {cwd: cwd});
@@ -37,6 +40,24 @@ module.exports = function (opts, cb) {
 		s.test = 'xo';
 	}
 
+	var cli = minimist(args);
+	var unicorn = cli.unicorn;
+
+	delete cli._;
+	delete cli.unicorn;
+	delete cli.init;
+
+	if (cli.env) {
+		cli.envs = arrify(cli.env);
+		delete cli.env;
+	}
+
+	if (Object.keys(cli).length) {
+		pkg.xo = cli;
+	} else if (pkg.xo) {
+		delete pkg.xo;
+	}
+
 	fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, '  ') + '\n');
 
 	childProcess.execFile('npm', ['install', '--save-dev', 'xo'], {cwd: cwd}, function (err) {
@@ -46,7 +67,7 @@ module.exports = function (opts, cb) {
 		}
 
 		// for personal use
-		if (hasFlag('unicorn')) {
+		if (unicorn) {
 			var pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 			pkg.devDependencies.xo = '*';
 			fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, '  ') + '\n');

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var minimist = require('minimist');
 var arrify = require('arrify');
 var argv = require('the-argv');
 var DEFAULT_TEST_SCRIPT = 'echo "Error: no test specified" && exit 1';
+var PLURAL_OPTIONS = ['env', 'global', 'ignore'];
 
 module.exports = function (opts, cb) {
 	if (typeof opts !== 'object') {
@@ -47,10 +48,12 @@ module.exports = function (opts, cb) {
 	delete cli.unicorn;
 	delete cli.init;
 
-	if (cli.env) {
-		cli.envs = arrify(cli.env);
-		delete cli.env;
-	}
+	PLURAL_OPTIONS.forEach(function (option) {
+		if (cli[option]) {
+			cli[option + 's'] = arrify(cli[option]);
+			delete cli[option];
+		}
+	});
 
 	if (Object.keys(cli).length) {
 		pkg.xo = cli;

--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
     "xo"
   ],
   "dependencies": {
-    "has-flag": "^1.0.0",
-    "look-up": "^0.7.1"
+    "arrify": "^1.0.0",
+    "exclude": "^1.0.0",
+    "look-up": "^0.7.1",
+    "minimist": "^1.1.3",
+    "the-argv": "^1.0.0"
   },
   "devDependencies": {
     "ava": "0.0.4",

--- a/readme.md
+++ b/readme.md
@@ -32,10 +32,29 @@ Default: `process.cwd()`
 
 Current working directory.
 
+#### options.args
+
+Type: `array`  
+Default: CLI arguments *(`process.argv.slice(2)`)*
+
+Options to put in [XO's config](https://www.npmjs.com/package/xo#config) in `package.json`.
+
+For instance, with the arguments `['--space', '--env=node']` the following will be put in `package.json`:
+
+```json
+{
+  "name": "your-awesome-project",
+  "xo": {
+    "space": true,
+    "envs": ["node"]
+  }
+}
+```
+
 
 ## CLI
 
-Install [XO](https://github.com/sindresorhus/xo) globally and run `$ xo --init`.
+Install [XO](https://github.com/sindresorhus/xo) globally and run `$ xo --init [<options>]`.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -147,3 +147,34 @@ test('has existing config without cli args', function (t) {
 		t.assert(dotProp.get(pkg, 'xo') === undefined);
 	});
 });
+
+test('has everything covered when it comes to config', function (t) {
+	t.plan(12);
+
+	process.argv = originalArgv.concat([
+		'--init',
+		'--space',
+		'--esnext',
+		'--no-semicolon',
+		'--env=foo',
+		'--env=bar',
+		'--global=foo',
+		'--global=bar',
+		'--ignore=foo',
+		'--ignore=bar'
+	]);
+
+	run(t, {}, function (pkg) {
+		process.argv = originalArgv;
+		t.assert(dotProp.get(pkg, 'scripts.test') === 'xo');
+		t.assert(dotProp.get(pkg, 'xo.space') === true);
+		t.assert(dotProp.get(pkg, 'xo.esnext') === true);
+		t.assert(dotProp.get(pkg, 'xo.semicolon') === false);
+		t.assert(dotProp.get(pkg, 'xo.envs.0') === 'foo');
+		t.assert(dotProp.get(pkg, 'xo.envs.1') === 'bar');
+		t.assert(dotProp.get(pkg, 'xo.globals.0') === 'foo');
+		t.assert(dotProp.get(pkg, 'xo.globals.1') === 'bar');
+		t.assert(dotProp.get(pkg, 'xo.ignores.0') === 'foo');
+		t.assert(dotProp.get(pkg, 'xo.ignores.1') === 'bar');
+	});
+});


### PR DESCRIPTION
This PR makes it possible to use XO's other arguments and they will then be added to package.json when initializing.

E.g. running: `xo --init --space` will add `xo --space` to `scripts.test`, instead of just `xo`.

What do you think?
