### PR TITLE
xo should run after other test scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function (opts) {
 	if (s.test && s.test !== DEFAULT_TEST_SCRIPT) {
 		// don't add if it's already there
 		if (!/^xo( |$)/.test(s.test)) {
-			s.test = 'xo && ' + s.test;
+			s.test += ' && xo';
 		}
 	} else {
 		s.test = 'xo';


### PR DESCRIPTION
You might want to just quickly test but you don't care about stylings for now. For example, you add a `console.log` or you add some scripts with no indentation, and then you wanna quickly run the test scripts.
