### PR TITLE
Use npm lifecycle script pretest

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,6 @@ var writePkg = require('write-pkg');
 var Promise = require('pinkie-promise');
 var pify = require('pify');
 
-var DEFAULT_TEST_SCRIPT = 'echo "Error: no test specified" && exit 1';
-
 var PLURAL_OPTIONS = [
 	'env',
 	'global',
@@ -55,13 +53,10 @@ module.exports = function (opts) {
 	var pkgCwd = path.dirname(pkgPath);
 	var s = pkg.scripts = pkg.scripts ? pkg.scripts : {};
 
-	if (s.test && s.test !== DEFAULT_TEST_SCRIPT) {
-		// don't add if it's already there
-		if (!/^xo( |$)/.test(s.test)) {
-			s.test = 'xo && ' + s.test;
-		}
-	} else {
-		s.test = 'xo';
+	if (!s.pretest) {
+		s.pretest = 'xo';
+	} else if (s.pretest && s.pretest.indexOf('xo') < 0) {
+		s.pretest = 'xo && ' + s.pretest;
 	}
 
 	var cli = minimist(opts.args || argv());

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && ava"
+    "pretest": "xo",
+    "test": "ava"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
- still accessible with `npm run pretest`, but is a more logical place
  for linting.

Fixes #3.
Closes #6.
