### PR TITLE
Prefer Yarn when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
   - '4'
 before_install:
   - npm i -g npm
+  - npm i -g yarn

--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ function warnConfigFile(pkgCwd) {
 	console.log(`${files.join(' & ')} can probably be deleted now that you're using XO.`);
 }
 
+function hasYarn(pkgCwd) {
+	return pathExists.sync(path.join(pkgCwd, 'yarn.lock'));
+}
+
 module.exports = opts => {
 	opts = opts || {};
 
@@ -98,6 +102,9 @@ module.exports = opts => {
 			});
 		}
 	};
-
-	return opts.skipInstall ? Promise.resolve(post) : execa('npm', ['install', '--save-dev', 'xo'], {cwd: pkgCwd}).then(post);
+	if (hasYarn(pkgCwd)) {
+		return opts.skipInstall ? Promise.resolve(post) : execa('yarn', ['add', '--dev', 'xo'], {cwd: pkgCwd}).then(post);
+	} else {
+		return opts.skipInstall ? Promise.resolve(post) : execa('npm', ['install', '--save-dev', 'xo'], {cwd: pkgCwd}).then(post);
+	}
 };

--- a/index.js
+++ b/index.js
@@ -104,7 +104,6 @@ module.exports = opts => {
 	};
 	if (hasYarn(pkgCwd)) {
 		return opts.skipInstall ? Promise.resolve(post) : execa('yarn', ['add', '--dev', 'xo'], {cwd: pkgCwd}).then(post);
-	} else {
-		return opts.skipInstall ? Promise.resolve(post) : execa('npm', ['install', '--save-dev', 'xo'], {cwd: pkgCwd}).then(post);
 	}
+	return opts.skipInstall ? Promise.resolve(post) : execa('npm', ['install', '--save-dev', 'xo'], {cwd: pkgCwd}).then(post);
 };

--- a/index.js
+++ b/index.js
@@ -39,9 +39,7 @@ function warnConfigFile(pkgCwd) {
 	console.log(`${files.join(' & ')} can probably be deleted now that you're using XO.`);
 }
 
-function hasYarn(pkgCwd) {
-	return pathExists.sync(path.join(pkgCwd, 'yarn.lock'));
-}
+const hasYarn = pkgCwd => pathExists.sync(path.join(pkgCwd, 'yarn.lock'));
 
 module.exports = opts => {
 	opts = opts || {};
@@ -102,8 +100,14 @@ module.exports = opts => {
 			});
 		}
 	};
-	if (hasYarn(pkgCwd)) {
-		return opts.skipInstall ? Promise.resolve(post) : execa('yarn', ['add', '--dev', 'xo'], {cwd: pkgCwd}).then(post);
+
+	if (opts.skipInstall) {
+		return Promise.resolve(post);
 	}
-	return opts.skipInstall ? Promise.resolve(post) : execa('npm', ['install', '--save-dev', 'xo'], {cwd: pkgCwd}).then(post);
+
+	if (hasYarn(pkgCwd)) {
+		return execa('yarn', ['add', '--dev', 'xo'], {cwd: pkgCwd}).then(post);
+	}
+
+	return execa('npm', ['install', '--save-dev', 'xo'], {cwd: pkgCwd}).then(post);
 };

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = opts => {
 		}
 	});
 
-	if (Object.keys(cli).length >== 0) {
+	if (Object.keys(cli).length > 0) {
 		pkg.xo = cli;
 	} else if (pkg.xo) {
 		delete pkg.xo;

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = opts => {
 		}
 	});
 
-	if (Object.keys(cli).length) {
+	if (Object.keys(cli).length >== 0) {
 		pkg.xo = cli;
 	} else if (pkg.xo) {
 		delete pkg.xo;

--- a/test.js
+++ b/test.js
@@ -165,6 +165,5 @@ test('installs the XO dependency', async t => {
 test('installs via yarn if there\'s a lockfile', async t => {
 	const yarnLock = tempWrite.sync('', 'yarn.lock');
 	await m({cwd: path.dirname(yarnLock)});
-	console.log(fs.readFileSync(yarnLock, 'utf8'));
-	t.not('', fs.readFileSync(yarnLock, 'utf8'));
+	t.not(fs.readFileSync(yarnLock, 'utf8'), '');
 });

--- a/test.js
+++ b/test.js
@@ -161,3 +161,10 @@ test('installs the XO dependency', async t => {
 	await m({cwd: path.dirname(filepath)});
 	t.truthy(get(JSON.parse(fs.readFileSync(filepath, 'utf8')), 'devDependencies.xo'));
 });
+
+test('installs via yarn if there\'s a lockfile', async t => {
+	const yarnLock = tempWrite.sync('', 'yarn.lock');
+	await m({cwd: path.dirname(yarnLock)});
+	console.log(fs.readFileSync(yarnLock, 'utf8'));
+	t.not('', fs.readFileSync(yarnLock, 'utf8'));
+});

--- a/test.js
+++ b/test.js
@@ -165,5 +165,5 @@ test('installs the XO dependency', async t => {
 test('installs via yarn if there\'s a lockfile', async t => {
 	const yarnLock = tempWrite.sync('', 'yarn.lock');
 	await m({cwd: path.dirname(yarnLock)});
-	t.not(fs.readFileSync(yarnLock, 'utf8'), '');
+	t.regex(fs.readFileSync(yarnLock, 'utf8'), /xo/);
 });


### PR DESCRIPTION
There's a bit repetition, should I maybe declare the `execa('npm', ['install', '--save-dev', 'xo'], {cwd: pkgCwd})` or `'npm', ['install', '--save-dev', 'xo']` as a variable and then use `...command`? I wasn't sure what was the best option.

```js
let command = {'npm', ['install', '--save-dev', 'xo']};
if (hasYarn(pkgCwd)) {
	command = {'yarn', ['add', '--dev', 'xo']};
}
return opts.skipInstall ? Promise.resolve(post) : execa(...command, {cwd: pkgCwd}).then(post);
```

That would look like this I think

closes #10

# Todo

- [x] add test
- [x] pass linting