### PR TITLE
Bump `execa`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "arrify": "^1.0.0",
-    "execa": "^0.5.0",
+    "execa": "^0.6.0",
     "has-yarn": "^1.0.0",
     "minimist": "^1.1.3",
     "path-exists": "^3.0.0",


### PR DESCRIPTION
Takes `pinkie-promise` out of the dependency tree.