### PR TITLE
Fix compability with Yarn 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ export default async function createXo(options = {}) {
 			} else {
 				await execa('yarn', ['add', '--dev', 'xo'], {cwd: packageCwd});
 			}
+			post();
 		} catch (error) {
 			if (error.code === 'ENOENT') {
 				console.error('This project uses Yarn but you don\'t seem to have Yarn installed.\nRun `npm install --global yarn` to install it.');

--- a/index.js
+++ b/index.js
@@ -94,8 +94,12 @@ export default async function createXo(options = {}) {
 
 	if (hasYarn(packageCwd)) {
 		try {
-			await execa('yarn', ['add', '--dev', '--ignore-workspace-root-check', 'xo'], {cwd: packageCwd});
-			post();
+			const version = parseFloat(await execa('yarn', ['--version'], {cwd: packageCwd}));
+			if (version < 2) {
+				await execa('yarn', ['add', '--dev', '--ignore-workspace-root-check', 'xo'], {cwd: packageCwd});
+			} else {
+				await execa('yarn', ['add', '--dev', 'xo'], {cwd: packageCwd});
+			}
 		} catch (error) {
 			if (error.code === 'ENOENT') {
 				console.error('This project uses Yarn but you don\'t seem to have Yarn installed.\nRun `npm install --global yarn` to install it.');


### PR DESCRIPTION
Yarn3 does not support `--ignore-workspace-root-check`

<details>
<summary>
error log
</summary>
```
C:\\node_modules\execa\lib\error.js:60
                error = new Error(message);
                        ^

Error: Command failed with exit code 1: yarn add --dev --ignore-workspace-root-check xo
Unknown Syntax Error: Unsupported option name ("--ignore-workspace-root-check").

$ yarn add [--json] [-E,--exact] [-T,--tilde] [-C,--caret] [-D,--dev] [-P,--peer] [-O,--optional] [--prefer-dev] [-i,--interactive] [--cached] [--mode #0] ...     
    at makeError (C:\\node_modules\execa\lib\error.js:60:11)
    at handlePromise (C:\\node_modules\execa\index.js:118:26)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async createXo (file:////node_modules/create-xo/index.js:97:4) {
  shortMessage: 'Command failed with exit code 1: yarn add --dev --ignore-workspace-root-check xo',
  command: 'yarn add --dev --ignore-workspace-root-check xo',
  escapedCommand: 'yarn add --dev --ignore-workspace-root-check xo',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: '\x1B[31m\x1B[1mUnknown Syntax Error\x1B[22m\x1B[39m: Unsupported option name ("--ignore-workspace-root-check").\n' +
    '\n' +
    '$ yarn add [--json] [-E,--exact] [-T,--tilde] [-C,--caret] [-D,--dev] [-P,--peer] [-O,--optional] [--prefer-dev] [-i,--interactive] [--cached] [--mode #0] ...',
  stderr: '',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}
```
</details>
